### PR TITLE
cmark: Handle Unicode return values from the include resolver

### DIFF
--- a/hotdoc/parsers/cmark_module.c
+++ b/hotdoc/parsers/cmark_module.c
@@ -166,6 +166,14 @@ resolve_include(const char *uri) {
 
   contents = PyObject_CallMethod(include_resolver, "resolve", "s", uri);
 
+  if (PyUnicode_Check(contents)) {
+    PyObject *old_contents;
+
+    old_contents = contents;
+    contents = PyUnicode_AsUTF8String(old_contents);
+    Py_DECREF(old_contents);
+  }
+
   if (contents != Py_None)
     res = strdup(PyString_AsString(contents));
 

--- a/hotdoc/parsers/tests/test_cmark_parser.py
+++ b/hotdoc/parsers/tests/test_cmark_parser.py
@@ -314,6 +314,8 @@ class MockIncludeResolver(object):
             return ""
         elif filename == 'opens_code_block.md':
             return "```"
+        elif filename == 'unicode_file.md':
+            return u"some Ünicode"
         return None
 
 
@@ -372,6 +374,12 @@ class TestIncludeExtension(unittest.TestCase):
         self.assertOutputs(
             inp,
             u'<p>I include an empty file!</p>\n')
+
+    def test_unicode(self):
+        inp = u'I include a file containing Unicode {{unicode_file.md}}!'
+        self.assertOutputs(
+            inp,
+            u'<p>I include a file containing Unicode some Ünicode!</p>\n')
 
 
 class TestTableExtension(unittest.TestCase):


### PR DESCRIPTION
As a Python function, the resolver might legitimately return a string or
a Unicode string; the C wrapper needs to be able to handle both, or it
will crash with a strdup(NULL) call, as PyString_AsString() of a
PyUnicodeObject is NULL.