### PR TITLE
Don't depend on exact version numbers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -274,10 +274,10 @@ INSTALL_REQUIRES = [
     'pyyaml',
     'lxml',
     'schema',
-    'wheezy.template==0.1.167',
+    'wheezy.template>=0.1.167',
     'pygraphviz>=1.3.rc2',
     'sqlalchemy>=1.0.8',
-    'toposort==1.4']
+    'toposort>=1.4']
 
 EXTRAS_REQUIRE = {
     'dev': ['git-pylint-commit-hook',


### PR DESCRIPTION
Hotdoc seems to work fine when these equal signs are changed to
greater-than-or-equal. Debian testing has toposort 1.5 now. (0.1.167
is currently the latest version of wheezy.template, though I've
changed it as well to avoid the same problem in the future.)