### PR TITLE
setup: Fix hotdoc_bootstrap_theme path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,8 @@ CMARK_MODULE = CMarkExtension('hotdoc.parsers.cmark',
 
 THEME_SRC_DIR = os.path.join(SOURCE_DIR, 'hotdoc', 'hotdoc_bootstrap_theme')
 THEME_DIST_DIR = os.path.join(THEME_SRC_DIR, 'dist')
-THEME_REL_DIR = os.path.relpath(THEME_DIST_DIR, start=SOURCE_DIR)
+THEME_REL_DIR = os.path.relpath(THEME_DIST_DIR, start=os.path.join(SOURCE_DIR,
+                                                                   'hotdoc'))
 require_clean_submodules(os.path.dirname(THEME_SRC_DIR),
                          'hotdoc_bootstrap_theme')
 


### PR DESCRIPTION
It was being included as package_data for 'hotdoc', so the path had to be
relative to 'hotdoc' as well.

A straggler from my previous pull request. It fixed the build, but hotdoc_bootstrap_theme wasn't being included in the binary. Oops!