### PR TITLE
build: Make startup script ASCII-only

### DIFF
--- a/hotdoc/hotdoc
+++ b/hotdoc/hotdoc
@@ -1,8 +1,7 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 #
-# Copyright © 2015,2016 Mathieu Duponchelle <mathieu.duponchelle@opencreed.com>
-# Copyright © 2015,2016 Collabora Ltd
+# Copyright 2015,2016 Mathieu Duponchelle <mathieu.duponchelle@opencreed.com>
+# Copyright 2015,2016 Collabora Ltd
 #
 # This library is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free


### PR DESCRIPTION
It seems to be a limitation of setuptools, that your startup script
cannot be in an encoding other than that of the environment. So if you
install Hotdoc with `pip install -e` or `setup.py develop` then try to
run it with LANG=C, you'll get a UnicodeDecodeError.

Removing the copyright signs from the startup script makes it work again.