### PR TITLE
Git upload remote repo path

### DIFF
--- a/hotdoc/extensions/git_upload/git_upload_extension.py
+++ b/hotdoc/extensions/git_upload/git_upload_extension.py
@@ -145,7 +145,7 @@ class GitUploadExtension(Extension):
 
             recursive_overwrite(built_f, copy_dest)
 
-            call(['git', 'add', copy_dest], cwd=repo)
+            call(['git', 'add', filename], cwd=repo)
 
         if self.__copy_only:
             return

--- a/hotdoc/extensions/git_upload/git_upload_extension.py
+++ b/hotdoc/extensions/git_upload/git_upload_extension.py
@@ -172,14 +172,14 @@ class GitUploadExtension(Extension):
                  "It can contain the path in which the html files reside.\n"
                  "Specifying it activates the upload.\n"
                  "NOTE: It should most probably never be in the config file."
-                 " - html files from that directory will be deleted and only.",
+                 " - html files from that directory will be deleted.",
             default=None)
         group.add_argument(
             '--git-upload-repository',
             help="Git repository to upload to.\n Will be used only if "
             "--git-upload-local-repo is not available.\n", default=None)
         group.add_argument('--git-upload-remote-branch',
-                           help="Remove/branch to push the update to",
+                           help="Remote/branch to push the update to",
                            default="origin/master")
         group.add_argument('--git-upload-commit-message',
                            help="Commit message to use for the update.",


### PR DESCRIPTION
Allows a subpath of a remote repo URL, such as `--git-upload-repository=https://github.com/hotdoc/hotdoc/docs/mydir`.