### PR TITLE
Add .js to include lang mapping

### DIFF
--- a/hotdoc/core/project.py
+++ b/hotdoc/core/project.py
@@ -40,6 +40,7 @@ from hotdoc.parsers.sitemap import SitemapParser
 
 
 LANG_MAPPING = {
+    'js': 'javascript',
     'xml': 'markup',
     'html': 'markup',
     'py': 'python'


### PR DESCRIPTION
Prism does recognize 'js' as a valid language, but only if
prism-javascript.min.js is loaded first. If there are no code blocks
with `class="language-javascript"`, then an included .js file won't
get highlighted. This should fix that.