### PR TITLE
Remove version in output names and make it informatory only

### DIFF
--- a/hotdoc/core/project.py
+++ b/hotdoc/core/project.py
@@ -256,9 +256,7 @@ class Project(Configurable):
         if not self.project_version:
             error('invalid-config', 'No project version was provided')
 
-        self.sanitized_name = '%s-%s' % (re.sub(r'\W+', '-',
-                                                self.project_name),
-                                         self.project_version)
+        self.sanitized_name = '%s' % (re.sub(r'\W+', '-', self.project_name))
 
     # pylint: disable=arguments-differ
     def parse_config(self, config, toplevel=False):


### PR DESCRIPTION
It was not really useful as we won't be able to build the documentation
of a same lib for two of its versions at the same time because of
symbole name uniqueness