### PR TITLE
setup: search for 'gmake' in addition to 'make'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ class BuildDefaultTheme(Command):
     """
     user_options = []
     description = ("Build default html theme, the following dependencies are "
-                   "required: make, npm")
+                   "required: GNU make, npm")
 
     # pylint: disable=missing-docstring
     def initialize_options(self):
@@ -165,9 +165,13 @@ class BuildDefaultTheme(Command):
     # pylint: disable=missing-docstring
     # pylint: disable=no-self-use
     def run(self):
-        if spawn.find_executable('make') is None:
-            print("make is required")
-            print("please get a version of make and re-run setup")
+        if spawn.find_executable('gmake') is not None:
+            gmake = 'gmake'
+        elif spawn.find_executable('make') is not None:
+            gmake = 'make'
+        else:
+            print("GNU make  is required")
+            print("please get a version of GNU make and re-run setup")
             sys.exit(-1)
         if spawn.find_executable('npm') is None:
             print("npm is required")
@@ -180,7 +184,7 @@ class BuildDefaultTheme(Command):
                 spawn.spawn(['./node_modules/bower/bin/bower', 'install', '--allow-root'])
                 os.environ['LESS_INCLUDE_PATH'] = os.path.join(
                     SOURCE_DIR, 'hotdoc', 'less')
-                spawn.spawn(['make'])
+                spawn.spawn([gmake])
                 del os.environ['LESS_INCLUDE_PATH']
                 with open(os.path.join(THEME_DIST_DIR, 'theme.json'), 'w') as _:
                     _.write(json.dumps({'prism-theme': 'prism-tomorrow', 'hotdoc-version': VERSION}))


### PR DESCRIPTION
hotdoc/hotdoc_bootstrap_theme/Makefile uses non-standard syntaxes which
are specific to GNU make. On platforms which uses BSD make as the
default make command, it causes the installation to fail because
Makefile cannot be parsed. 'gmake' is a common name for GNU make on
systems which don't use GNU make as the default make command, so
searching for 'gmake' first is much likely to find the correct make.

This fixes installation failure on FreeBSD:
```
    make
    make: "/home/lantw44/gnome/source/hotdoc/hotdoc/hotdoc_bootstrap_theme/Makefile" line 20: Need an operator
    make: "/home/lantw44/gnome/source/hotdoc/hotdoc/hotdoc_bootstrap_theme/Makefile" line 27: Need an operator
    make: "/home/lantw44/gnome/source/hotdoc/hotdoc/hotdoc_bootstrap_theme/Makefile" line 51: Need an operator
    make: "/home/lantw44/gnome/source/hotdoc/hotdoc/hotdoc_bootstrap_theme/Makefile" line 53: Need an operator
    make: "/home/lantw44/gnome/source/hotdoc/hotdoc/hotdoc_bootstrap_theme/Makefile" line 62: Need an operator
    make: "/home/lantw44/gnome/source/hotdoc/hotdoc/hotdoc_bootstrap_theme/Makefile" line 66: Need an operator
    make: "/home/lantw44/gnome/source/hotdoc/hotdoc/hotdoc_bootstrap_theme/Makefile" line 73: Need an operator
    make: "/home/lantw44/gnome/source/hotdoc/hotdoc/hotdoc_bootstrap_theme/Makefile" line 81: Need an operator
    make: "/home/lantw44/gnome/source/hotdoc/hotdoc/hotdoc_bootstrap_theme/Makefile" line 85: Need an operator
    make: "/home/lantw44/gnome/source/hotdoc/hotdoc/hotdoc_bootstrap_theme/Makefile" line 93: Need an operator
    make: "/home/lantw44/gnome/source/hotdoc/hotdoc/hotdoc_bootstrap_theme/Makefile" line 101: Need an operator
    make: Fatal errors encountered -- cannot continue
    make: stopped in /home/lantw44/gnome/source/hotdoc/hotdoc/hotdoc_bootstrap_theme
    Error while building default theme command 'make' failed with exit status 1
```