### PR TITLE
remove unneeded pin on python-pkgconfig version

### DIFF
--- a/hotdoc/utils/utils.py
+++ b/hotdoc/utils/utils.py
@@ -20,9 +20,8 @@
 Toolbox
 """
 
-import collections
-# pylint: disable=no-name-in-module
-from collections import OrderedDict, Callable
+from collections import OrderedDict
+from collections.abc import Callable, MutableSet
 import os
 import shutil
 import math
@@ -217,7 +216,7 @@ def get_extension_classes(sort, extra_extension_paths=None):
 # Recipe from http://code.activestate.com/recipes/576694/
 
 
-class OrderedSet(collections.MutableSet):
+class OrderedSet(MutableSet):
     """
     Banana banana
     """

--- a/setup.py
+++ b/setup.py
@@ -315,7 +315,7 @@ INSTALL_REQUIRES = [
     'lxml',
     'schema',
     'appdirs',
-    'wheezy.template==0.1.167',
+    'wheezy.template',
     'toposort>=1.4',
     'xdg>=4.0.0',
 ]

--- a/setup.py
+++ b/setup.py
@@ -416,7 +416,7 @@ if build_c_extension != 'disabled':
         INSTALL_REQUIRES += [
             'pkgconfig',
             'cchardet',
-            'networkx==2.5'
+            'networkx>=2.5'
         ]
         PACKAGE_DATA['hotdoc.extensions.gi'] = ['html_templates/*']
         PACKAGE_DATA['hotdoc.extensions.gi.transition_scripts'] = ['translate_sections.sh']

--- a/setup.py
+++ b/setup.py
@@ -414,7 +414,7 @@ if build_c_extension != 'disabled':
                             ['hotdoc/parsers/c_comment_scanner/scanner.l',
                             'hotdoc/parsers/c_comment_scanner/scanner.h'])]
         INSTALL_REQUIRES += [
-            'pkgconfig==1.1.0',
+            'pkgconfig',
             'cchardet',
             'networkx==2.5'
         ]


### PR DESCRIPTION
The current pin is for a version from 2013, and it hasn't broken in 7 years of backwards-compatible releases. Out of a bunch of dependencies in this project, this should not be a high priority to pin!