### PR TITLE
drop dependency on xdg

### DIFF
--- a/hotdoc/parsers/gtk_doc.py
+++ b/hotdoc/parsers/gtk_doc.py
@@ -27,7 +27,6 @@ import re
 import cgi
 from collections import OrderedDict
 from itertools import zip_longest
-from xdg import XDG_DATA_HOME, XDG_DATA_DIRS
 from lxml import etree
 
 import yaml
@@ -40,6 +39,7 @@ from hotdoc.core.links import Link
 from hotdoc.utils.configurable import Configurable
 from hotdoc.parsers import cmark
 from hotdoc.utils.loggable import Logger, warn, info
+from hotdoc.utils.utils import XDG_DATA_HOME, XDG_DATA_DIRS
 
 Logger.register_warning_code('gtk-doc', HotdocSourceException)
 Logger.register_warning_code('gtk-doc-bad-link', HotdocSourceException)
@@ -654,4 +654,3 @@ def search_online_links(resolver, name):
     if href:
         return Link(href, name, name)
     return None
-

--- a/hotdoc/utils/utils.py
+++ b/hotdoc/utils/utils.py
@@ -47,6 +47,8 @@ if os.name == 'nt':
 else:
     DATADIR = "/usr/share"
 
+XDG_DATA_DIRS = os.getenv('XDG_DATA_DIRS','/usr/local/share/:/usr/share/').split(':')
+XDG_DATA_HOME = os.getenv('XDG_DATA_HOME', os.path.expanduser('~/.local/share'))
 
 def splitall(path):
     """

--- a/setup.py
+++ b/setup.py
@@ -317,7 +317,6 @@ INSTALL_REQUIRES = [
     'appdirs',
     'wheezy.template',
     'toposort>=1.4',
-    'xdg>=4.0.0',
 ]
 
 # dbus-deviation requires sphinx, which requires python 3.5


### PR DESCRIPTION
It's trivially implemented in a couple lines of os.getenv, and the xdg module clashes with the *other* xdg module.

https://pypi.org/project/xdg/
https://pypi.org/project/pyxdg/

The former is a relatively recent package that ONLY provides the XDG base directory specification, but calls itself "xdg".

The latter is Freedesktop's own module that has been around for a lot longer, and provides the base directory variables in the submodule xdg.BaseDirectory.*, in addition to providing code relevant to several other xdg standards.

The existence of the former is confusing and redundant, and the use of either one is a bit overkill; the spec is not complicated, let's just provide it ourselves.