### PR TITLE
gi: Add class structure fields as children of the GIClassSymbol

### DIFF
--- a/hotdoc/core/symbols.py
+++ b/hotdoc/core/symbols.py
@@ -104,8 +104,9 @@ class Symbol:
             if isinstance(sym, ParameterSymbol):
                 sym.comment = self.comment.params.get(sym.argname)
             elif isinstance(sym, FieldSymbol):
-                if not sym.comment or not sym.comment.description:
-                    sym.comment = self.comment.params.get(sym.member_name)
+                param_comment = self.comment.params.get(sym.member_name)
+                if param_comment and (not sym.comment or not sym.comment.description):
+                    sym.comment = param_comment
             elif isinstance(sym, EnumMemberSymbol):
                 if not sym.comment or not sym.comment.description:
                     sym.comment = self.comment.params.get(sym.unique_name)

--- a/hotdoc/extensions/gi/symbols.py
+++ b/hotdoc/extensions/gi/symbols.py
@@ -30,8 +30,13 @@ class GIClassSymbol(ClassSymbol):
         ClassSymbol.__init__(self, **kwargs)
 
     def get_children_symbols(self):
-        return [self.class_struct_symbol] + self.interfaces + self.properties + self.methods + self.signals + self.vfuncs + super().get_children_symbols()
+        res = self.interfaces + self.properties + self.methods + \
+            self.signals + self.vfuncs + super().get_children_symbols()
 
+        if self.class_struct_symbol:
+           res += [self.class_struct_symbol] + self.class_struct_symbol.get_children_symbols()
+
+        return res
 
 class GIInterfaceSymbol(InterfaceSymbol):
     def __init__(self, **kwargs):


### PR DESCRIPTION
This way we set comments on them and they are properly taken into account to check Since markers.