### PR TITLE
make page output deterministic

### DIFF
--- a/hotdoc/core/formatter.py
+++ b/hotdoc/core/formatter.py
@@ -737,8 +737,8 @@ class Formatter(Configurable):
 
         out = template.render(
             {'page': page,
-             'scripts': scripts_basenames,
-             'stylesheets': stylesheets_basenames,
+             'scripts': sorted(scripts_basenames),
+             'stylesheets': sorted(stylesheets_basenames),
              'rel_path': rel_path,
              'attrs': page.output_attrs['html'],
              'meta': {},


### PR DESCRIPTION
It used to have randomly sorted JS/CSS, possibly based on filesystem ordering. This made diffing between versions of the site hard, and git commit logs for the generated site (e.g. $forge Pages) very noisy.

Fixes #114