### PR TITLE
CI: use pip for editable installs

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -30,6 +30,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install wheel
-        python3 setup.py develop
+        pip install --editable .
     - name: Test
       run: python3 -m unittest


### PR DESCRIPTION
Using python setup.py develop directly is a very hairy approach... it means all dependencies are getting resolved via easy_install and the resulting breakage is atrocious (installing prereleases of dependencies, not respecting python_requires).

easy_install is totally deprecated and should never be used... pip install --editable wraps setuptools develop mode while using the pip dependency resolver which is actually maintained and therefore works.