### PR TITLE
Fix segfault in search_module.c

### DIFF
--- a/hotdoc/core/extension.py
+++ b/hotdoc/core/extension.py
@@ -367,7 +367,7 @@ class Extension(Configurable):
         # Finally we make our index page
         if self.index:
             index_page = self.project.tree.parse_page(
-                self.index, self.extension_name)
+                self.index, next(iter(self.project.include_paths)), self.extension_name)
         else:
             index_page = Page('%s-index' % self.argument_prefix, True, self.project.sanitized_name,
                               self.extension_name)

--- a/hotdoc/core/inclusions.py
+++ b/hotdoc/core/inclusions.py
@@ -47,15 +47,15 @@ def find_file(filename, include_paths):
     """
     if os.path.isabs(filename):
         if os.path.exists(filename):
-            return filename
-        return None
+            return (filename, None)
+        return (None, None)
 
     for include_path in include_paths:
         fpath = os.path.join(include_path, filename)
         if os.path.exists(fpath) and os.path.isfile(fpath):
-            return fpath
+            return (fpath, include_path)
 
-    return None
+    return (None, None)
 
 
 def __parse_include(include):
@@ -80,8 +80,8 @@ def __parse_include(include):
     return (include_filename, line_ranges, symbol)
 
 
-def __get_content(include_path, line_ranges, symbol):
-    for c in include_signal(include_path, line_ranges, symbol):
+def __get_content(fpath, line_ranges, symbol):
+    for c in include_signal(fpath, line_ranges, symbol):
         if c is not None:
             included_content, lang = c
             if lang != "markdown":
@@ -98,8 +98,8 @@ def resolve(uri, include_paths):
     include_filename, line_ranges, symbol = __parse_include(uri)
     if include_filename is None:
         return None
-    include_path = find_file(include_filename, include_paths)
-    if include_path is None:
+    (fpath, include_path) = find_file(include_filename, include_paths)
+    if fpath is None:
         return None
-    return __get_content(include_path.strip(),
+    return __get_content(fpath.strip(),
                          line_ranges, symbol)

--- a/hotdoc/core/tests/test_inclusions.py
+++ b/hotdoc/core/tests/test_inclusions.py
@@ -30,18 +30,18 @@ class TestFileIncluder(HotdocTest):
         self._core_ext.setup()
 
     def test_missing_abspath(self):
-        self.assertEqual(find_file('/nope.md', []), None)
+        self.assertEqual(find_file('/nope.md', []), (None, None))
 
     def test_abspath(self):
         path = self._create_md_file('yep.md', 'stuff')
-        self.assertEqual(find_file(path, []), path)
+        self.assertEqual(find_file(path, []), (path, None))
 
     def test_relpath(self):
         path = self._create_md_file('yep.md', 'stuff')
-        self.assertEqual(find_file('yep.md', [self._md_dir]), path)
+        self.assertEqual(find_file('yep.md', [self._md_dir]), (path, self._md_dir))
 
     def test_missing_relpath(self):
-        self.assertEqual(find_file('yep.md', [self._md_dir]), None)
+        self.assertEqual(find_file('yep.md', [self._md_dir]), (None, None))
 
     def test_resolve(self):
         _ = self._create_md_file('yep.md', 'stuff')

--- a/hotdoc/parsers/search_module.c
+++ b/hotdoc/parsers/search_module.c
@@ -470,7 +470,7 @@ fill_fragment (gchar *key, GList *list, IndexContext *idx_ctx)
     g_string_append (text_string, tmp->data);
   }
 
-  text = g_string_free (text_string, FALSE); 
+  text = g_string_free (text_string, FALSE);
 
   jroot = json_node_new(JSON_NODE_OBJECT);
   jfragment = json_object_new();
@@ -640,6 +640,7 @@ fill_url (gchar *key, GList *list, IndexContext *ctx)
   gchar *filename;
   gchar *contents;
   FILE *f;
+  gboolean ret = TRUE;
 
   deduped = g_hash_table_new (g_str_hash, g_str_equal);
 
@@ -660,9 +661,15 @@ fill_url (gchar *key, GList *list, IndexContext *ctx)
   filename = g_build_filename (ctx->search_dir, key, NULL);
 
   f = fopen (filename, "w");
+  if (!f) {
+    fprintf(stderr, "Failed to open '%s' for writing\n", filename);
+    ret = FALSE;
+    goto cleanup;
+  }
   fwrite (contents, sizeof (gchar), strlen(contents), f);
   fclose(f);
 
+cleanup:
   g_free (contents);
   g_free (filename);
 
@@ -671,7 +678,7 @@ fill_url (gchar *key, GList *list, IndexContext *ctx)
 
   g_list_free_full (list, (GDestroyNotify) free_contextualized_url);
 
-  return TRUE;
+  return ret;
 }
 
 static gpointer


### PR DESCRIPTION
This PR fixes a segfault in `search_module.c` and improves the logic for handling relative paths for the generated HTML files.