### PR TITLE
symbols: do not list aliases as children

### DIFF
--- a/hotdoc/core/symbols.py
+++ b/hotdoc/core/symbols.py
@@ -89,7 +89,7 @@ class Symbol:
         """
         Banana banana
         """
-        return self.aliases
+        return []
 
     # pylint: disable=unidiomatic-typecheck
     # pylint: disable=no-member


### PR DESCRIPTION
This fixes a problem in resolving alias links.  That latter is illustrated by the online GStreamer plugins documentation, e.g. https://gstreamer.freedesktop.org/documentation/audiorate/index.html?gi-language=c.  There are quite some property references in the description, and they end up with empty title and a dangling `href`.

See the commit message for additional details. Of course, there may be other ways to address this, such as explicitly also resolving the alias links (e.g. in `Page.__resolve_symbols), etc.