### PR TITLE
extensions/dbus: Don't crash when comment is missing

### DIFF
--- a/hotdoc/extensions/dbus/dbus_extension.py
+++ b/hotdoc/extensions/dbus/dbus_extension.py
@@ -100,7 +100,8 @@ class DBusScanner(object):
     def __create_function_symbol (self, node):
         unique_name = '%s.%s' % (self.__current_class_name, node.name)
         comment = self.__comment_from_node(node, unique_name)
-        self.__ext.add_comment(comment)
+        if comment:
+            self.__ext.add_comment(comment)
         parameters = self.__create_parameters (node.arguments)
 
         self.__ext.create_symbol(FunctionSymbol,
@@ -112,7 +113,8 @@ class DBusScanner(object):
     def __create_class_symbol (self, node):
         self.__current_class_name = node.name
         comment = self.__comment_from_node(node, node.name)
-        self.__ext.add_comment(comment)
+        if comment:
+            self.__ext.add_comment(comment)
         self.__ext.create_symbol(ClassSymbol,
                 display_name=node.name,
                 filename=self.__current_filename)
@@ -120,7 +122,8 @@ class DBusScanner(object):
     def __create_property_symbol (self, node):
         unique_name = '%s.%s' % (self.__current_class_name, node.name)
         comment = self.__comment_from_node(node, unique_name)
-        self.__ext.add_comment(comment)
+        if comment:
+            self.__ext.add_comment(comment)
 
         type_tokens = [str(node.type)]
         type_ = QualifiedSymbol (type_tokens=type_tokens)
@@ -145,7 +148,8 @@ class DBusScanner(object):
     def __create_signal_symbol (self, node):
         unique_name = '%s.%s' % (self.__current_class_name, node.name)
         comment = self.__comment_from_node(node, unique_name)
-        self.__ext.add_comment(comment)
+        if comment:
+            self.__ext.add_comment(comment)
 
         parameters = self.__create_parameters (node.arguments,
                 omit_direction=True)


### PR DESCRIPTION
dbus_extension.py on multiple places will call add_comment with None as the argument if no comment is present. The add_comment function does not handle None as an argument, so this change checks for None before calling.

Example of a traceback I got before this fix:

```
An unknown error happened while building the documentation and hotdoc cannot recover from it. Please report a bug with this error message and the steps to reproduce it
Traceback (most recent call last):
  File "/home/johanbj/.local/lib/python3.9/site-packages/hotdoc/run_hotdoc.py", line 294, in execute_command
    app.run()
  File "/home/johanbj/.local/lib/python3.9/site-packages/hotdoc/run_hotdoc.py", line 107, in run
    self.project.setup()
  File "/home/johanbj/.local/lib/python3.9/site-packages/hotdoc/core/project.py", line 183, in setup
    extension.setup()
  File "/home/johanbj/.local/lib/python3.9/site-packages/hotdoc/extensions/dbus/dbus_extension.py", line 177, in setup
    self.scanner = DBusScanner (self.app, self.project, self, self.sources)
  File "/home/johanbj/.local/lib/python3.9/site-packages/hotdoc/extensions/dbus/dbus_extension.py", line 45, in __init__
    self.__create_property_symbol (prop)
  File "/home/johanbj/.local/lib/python3.9/site-packages/hotdoc/extensions/dbus/dbus_extension.py", line 123, in __create_property_symbol
    self.__ext.add_comment(comment)
  File "/home/johanbj/.local/lib/python3.9/site-packages/hotdoc/core/extension.py", line 590, in add_comment
    if comment.toplevel:
AttributeError: 'NoneType' object has no attribute 'toplevel'
```