### PR TITLE
hotdoc_dep_printer: fix Config class name

### DIFF
--- a/hotdoc/hotdoc_dep_printer.py
+++ b/hotdoc/hotdoc_dep_printer.py
@@ -22,13 +22,13 @@
 
 import sys
 
-from hotdoc.core.config import ConfigParser
+from hotdoc.core.config import Config
 
 def main():
     if len(sys.argv) != 2:
         print("USAGE: %s path/to/conf/file" % sys.argv[0])
         sys.exit(1)
 
-    PARSER = ConfigParser(conf_file=sys.argv[1])
+    PARSER = Config(conf_file=sys.argv[1])
     PARSER.print_make_dependencies()
     sys.exit(0)


### PR DESCRIPTION
Commit 212d202 changed the name of the configuration class in `hotdoc.core.config` from `ConfigParser` to just `Config`.

`hotdoc_dep_printer.py` was still using the old name, making it unusable.

(And even un-importable, so no `pydoc` access:)

```console
$ pydoc3 hotdoc.hotdoc_dep_printer
problem in hotdoc.hotdoc_dep_printer - ImportError:
 cannot import name 'ConfigParser' from 'hotdoc.core.config'
 (.../site-packages/hotdoc/core/config.py)
