### PR TITLE
workflows: remove CI for 3.6

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.11]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
And add 3.11 instead, CI was failing github side for 3.6 with:

> Error: Version 3.6 with arch x64 not found