### PR TITLE
gst_extension: don't duplicate plugin documentation

### DIFF
--- a/hotdoc/extensions/gst/gst_extension.py
+++ b/hotdoc/extensions/gst/gst_extension.py
@@ -188,11 +188,12 @@ class GstPluginSymbol(Symbol):
     TEMPLATE = """
         @require(symbol, unique_feature)
         @if not unique_feature:
+        @if not symbol.formatted_doc:
         <h1>@symbol.display_name</h1>
+        @end
         <i>(from @symbol.package)</i>
         @end
         <div class="base_symbol_container">
-        @symbol.formatted_doc
         @if not unique_feature:
         <table class="table table-striped table-hover">
             <tbody>

--- a/hotdoc/tests/test_hotdoc.py
+++ b/hotdoc/tests/test_hotdoc.py
@@ -85,7 +85,7 @@ class TestHotdoc(unittest.TestCase):
     def assertOutput(self, n_html_files):
         actual = 0
         for f in os.listdir(os.path.join(self.__output_dir, 'html')):
-            if f.endswith('.html'):
+            if f.endswith('.html') and f != "hotdoc-sitemap.html":
                 actual += 1
         self.assertEqual(actual, n_html_files)
 


### PR DESCRIPTION
When symbol.formatted_doc exists, it is already rendered by the base template. When it is not, add the plugin display name as the title.