### PR TITLE
c_extension: Fix clang header detection

### DIFF
--- a/hotdoc/extensions/c/c_extension.py
+++ b/hotdoc/extensions/c/c_extension.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
-import os, sys, linecache, pkgconfig, glob, subprocess, shutil
+import os, sys, itertools, linecache, pkgconfig, glob, subprocess, shutil
 
 from hotdoc.extensions.c.clang import cindex
 from ctypes import *
@@ -77,9 +77,11 @@ CLANG_HEADERS_WARNING = (
 def get_clang_headers():
     version = subprocess.check_output(['llvm-config', '--version']).strip().decode()
     prefix = subprocess.check_output(['llvm-config', '--prefix']).strip().decode()
-
-    for lib in ['lib', 'lib64']:
-        p = os.path.join(prefix, lib, 'clang', version, 'include')
+    versions = (version, version.split('.').pop(0))
+    for (ver, lib) in itertools.product(
+            versions,
+            ['lib', 'lib64']):
+        p = os.path.join(prefix, lib, 'clang', ver, 'include')
         if os.path.exists(p):
             return p
 

--- a/hotdoc/extensions/c/c_extension.py
+++ b/hotdoc/extensions/c/c_extension.py
@@ -86,9 +86,10 @@ def get_clang_headers():
         # Clang 5.0+ can tell us directly
         resource_dir = subprocess.check_output(
             ['clang', '--print-resource-dir']).strip().decode()
-        include_dir = os.path.join(resource_dir, 'include')
-        if os.path.exists(include_dir):
-            return include_dir
+        if len(resource_dir) > 0:
+            include_dir = os.path.join(resource_dir, 'include')
+            if os.path.exists(include_dir):
+                return include_dir
     except subprocess.CalledProcessError:
         pass
     version = subprocess.check_output(

--- a/hotdoc/extensions/c/c_extension.py
+++ b/hotdoc/extensions/c/c_extension.py
@@ -82,6 +82,15 @@ CLANG_HEADERS_WARNING = (
 
 
 def get_clang_headers():
+    try:
+        # Clang 5.0+ can tell us directly
+        resource_dir = subprocess.check_output(
+            ['clang', '--print-resource-dir']).strip().decode()
+        include_dir = os.path.join(resource_dir, 'include')
+        if os.path.exists(include_dir):
+            return include_dir
+    except subprocess.CalledProcessError:
+        pass
     version = subprocess.check_output(
         ['llvm-config', '--version']).strip().decode()
     prefix = subprocess.check_output(


### PR DESCRIPTION
Clang version N.M.O now installs files to `{libdir}/clang/N/` instead of `{libdir}/clang/N.M.O/`. Check both possibilities when scanning for headers.

(The ordering on the `itertools.product` will first check the full version under `lib`, then `lib64`, and then do the same for the major-version number.)