### PR TITLE
annotation_parser: Fix comment reference

### DIFF
--- a/hotdoc/extensions/gi/annotation_parser.py
+++ b/hotdoc/extensions/gi/annotation_parser.py
@@ -73,7 +73,7 @@ DEFAULT_HELP = \
 DESTROY_HELP = \
 "The parameter is a 'destroy_data' for callbacks."
 
-# VERY DIFFERENT FROM THE PREVIOUS ONE BEWARE :P
+# VERY DIFFERENT FROM 'DEFAULT_HELP' BEWARE :P
 OPTIONAL_HELP = \
 "NULL may be passed instead of a pointer to a location"
 


### PR DESCRIPTION
A comment above `OPTIONAL_HELP` mentioned "the previous one", which made sense until commit 93eea55 inserted a message between them.

To protect against future ordering changes, reference the other message by name instead of proximity.