### PR TITLE
extensions: Stop doing line-by-line character set detection

### DIFF
--- a/hotdoc/extensions/c/utils.py
+++ b/hotdoc/extensions/c/utils.py
@@ -4,18 +4,10 @@ import cchardet
 from hotdoc.parsers.c_comment_scanner.c_comment_scanner import extract_comments
 
 from hotdoc.core.symbols import *
-from hotdoc.utils.loggable import debug
+from hotdoc.utils.loggable import debug, error
 
 
 RawMacro = namedtuple('RawMacro', ['raw', 'filename'])
-
-
-def unicode_dammit(data):
-    encoding = cchardet.detect(data)['encoding']
-    try:
-        return data.decode(encoding, errors='replace')
-    except LookupError:
-        return data.decode('utf8', errors='replace')
 
 
 class CCommentExtractor:
@@ -28,14 +20,13 @@ class CCommentExtractor:
 
     def parse_comments(self, filenames):
         for filename in filenames:
-            with open(filename, 'rb') as f:
+            with open(filename, 'r', encoding='utf-8') as f:
                 debug('Getting comments in %s' % filename)
                 lines = []
                 header = filename.endswith('.h')
                 skip_next_symbol = header
                 # FIXME Use the lexer for that!
                 for l in f.readlines():
-                    l = unicode_dammit(l)
                     lines.append(l)
                     if skip_next_symbol and l.startswith("#pragma once"):
                         skip_next_symbol = False

--- a/hotdoc/extensions/gi/transition_scripts/hotdoc_gtk_doc_porter
+++ b/hotdoc/extensions/gi/transition_scripts/hotdoc_gtk_doc_porter
@@ -47,7 +47,6 @@ from hotdoc.core.database import Database
 from hotdoc.core.links import Link
 from hotdoc.parsers.gtk_doc import GtkDocStringFormatter
 from hotdoc.extensions.gi.gi_extension import GIExtension
-from hotdoc.extensions.c.utils import unicode_dammit
 from hotdoc.utils.loggable import warn, info, debug, Logger
 
 from hotdoc.utils.utils import all_subclasses, get_extension_classes
@@ -68,11 +67,15 @@ class Patcher(object):
         if "Miscellaneous.default_page" in filename:
             return
 
+        fix_quotes = str.maketrans({
+            "\u2019": "'",
+            "\u201c": '"',
+            "\u201d": '"',
+        })
         lines = []
-        with open(filename, 'rb') as _:
+        with open(filename, 'r', encoding='utf8') as _:
             for l in _.readlines():
-                lines.append(unicode_dammit(
-                    l.replace(b'\xc3\xa2\xe2\x82\xac\xe2\x84\xa2', b"'")))
+                lines.append(l.translate(fix_quotes))
 
         res = lines[0:begin] + [new_comment + '\n'] + lines[end:]
         res = ''.join(res)


### PR DESCRIPTION
The line-by-line detection defintely broke with emojis in UTF-8 encoded files, and it doesn't make sense anyway.

For simplicity, let's stop doing character set detection at all, and expect input to be UTF-8.