### PR TITLE
Add a workflow to label PRs with merge conflicts

### DIFF
--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -1,0 +1,26 @@
+name: "Label merge conflicts"
+on:
+  # So that PRs touching the same files as the push are updated
+  push:
+  # So that the `dirtyLabel` is removed if conflicts are resolve
+  # We recommend `pull_request_target` so that github secrets are available.
+  # In `pull_request` we wouldn't be able to change labels of fork PRs
+  pull_request_target:
+    # GitHub documents "synchronize" as:
+    # A pull request's head branch was updated. For example, the head branch
+    # was updated from the base branch or new commits were pushed to the
+    # head branch.
+    types: [synchronize]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check if PRs are mergeable
+        uses: eps1lon/actions-label-merge-conflict@v2.1.0
+        with:
+          dirtyLabel: "conflicts"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: "This pull request has conflicts, please resolve those so that the changes can be evaluated."
+          commentOnClean: "All conflicts have been resolved, thanks!"
+


### PR DESCRIPTION
A completely take-it-or-leave-it suggestion, something I've used in other projects. This PR adds an Actions workflow (using [eps1lon/actions-label-merge-conflict](https://github.com/eps1lon/actions-label-merge-conflict)) that implements a missing GitHub feature: The ability to see, at a glance from the PR list, which PRs are mergeable and which aren't.

Before merging this, a label for PRs with conflicts should be created at https://github.com/hotdoc/hotdoc/labels. Its name should match the `dirtyLabel` option passed to the action. I've initially set that to `"conflicts"`, but it can be anything.

There are also two automated PR comment texts in the config, I'd appreciate a review of their content as well. (It's also possible to delete either or both of those messages, and have the action do its labeling work in silence.)