### PR TITLE
Remove LinkPreCommitHook from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -203,40 +203,12 @@ class BuildDefaultTheme(Command):
                 sys.exit(-1)
 
 
-class LinkPreCommitHook(Command):
-    """
-    This will create links to the pre-commit hook.
-    Only called in develop mode.
-    """
-    user_options = []
-    description = "Create links for the style checking pre-commit hooks"
-
-    # pylint: disable=missing-docstring
-    def initialize_options(self):
-        pass
-
-    # pylint: disable=missing-docstring
-    def finalize_options(self):
-        pass
-
-    # pylint: disable=missing-docstring
-    # pylint: disable=no-self-use
-    def run(self):
-        try:
-            symlink(os.path.join(SOURCE_DIR, 'pre-commit'),
-                    os.path.join(SOURCE_DIR, '.git', 'hooks', 'pre-commit'))
-        except OSError as error:
-            if error.errno != errno.EEXIST:
-                raise
-
-
 # pylint: disable=missing-docstring
 # pylint: disable=too-few-public-methods
 class CustomDevelop(develop):
 
     def run(self):
         self.run_command('build_default_theme')
-        self.run_command('link_pre_commit_hook')
         return develop.run(self)
 
 
@@ -457,7 +429,6 @@ setup(
               'bdist_egg': CustomBDistEgg,
               'develop': CustomDevelop,
               'test': DiscoverTest,
-              'link_pre_commit_hook': LinkPreCommitHook,
               'build_default_theme': BuildDefaultTheme},
     package_data=PACKAGE_DATA,
     install_requires=INSTALL_REQUIRES,


### PR DESCRIPTION
I missed that there was `pre-commit` integration in `setup.py` that should no longer be there (as it no longer works after #266).

At some point we can look at replacing this with a command runner than installs `pre-commit`, then runs `pre-commit install --install-hooks`, the moral equivalent. But for right now, with the old `pre-commit` script removed from the repo, the only function this has is to break attempted development builds/installs.