### PR TITLE
Remove unused cchardet import and dependency

### DIFF
--- a/hotdoc/extensions/c/utils.py
+++ b/hotdoc/extensions/c/utils.py
@@ -1,6 +1,6 @@
 import os
 from collections import namedtuple
-import cchardet
+
 from hotdoc.parsers.c_comment_scanner.c_comment_scanner import extract_comments
 
 from hotdoc.core.symbols import *

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ chardet==5.2.0
 colorama==0.4.6
 dbus-deviation==0.6.1
 distlib==0.3.9
-faust-cchardet==2.1.19
 filelock==3.18.0
 -e git+ssh://git@github.com/hotdoc/hotdoc.git@e3c2a0923b87f676b517e695a936a3ca9d79377e#egg=hotdoc
 iniconfig==2.1.0

--- a/setup.py
+++ b/setup.py
@@ -361,7 +361,6 @@ if build_c_extension != 'disabled':
                      'hotdoc/parsers/c_comment_scanner/scanner.h'])]
         INSTALL_REQUIRES += [
             'pkgconfig',
-            'faust-cchardet',
             'networkx>=2.5'
         ]
         PACKAGE_DATA['hotdoc.extensions.gi'] = ['html_templates/*']


### PR DESCRIPTION
Not used since:
2f3bb61 ("extensions: Stop doing line-by-line character set detection", 2023-10-13)