### PR TITLE
Eliminate dependency on deprecated setuptools.pkg_resources

### DIFF
--- a/hotdoc/extensions/gi/utils.py
+++ b/hotdoc/extensions/gi/utils.py
@@ -212,7 +212,7 @@ def get_language_classes():
             classes = activation_function()
         # pylint: disable=broad-except
         except Exception as exc:
-            info("Failed to load %s" % entry_point, exc)
+            info("Failed to load %s" % str(entry_point), exc)
             debug(traceback.format_exc())
             continue
 

--- a/hotdoc/extensions/gi/utils.py
+++ b/hotdoc/extensions/gi/utils.py
@@ -1,10 +1,12 @@
 import os
 from collections import namedtuple
 import pathlib
+import traceback
 
 from backports.entry_points_selectable import entry_points
 
 from hotdoc.core.links import Link
+from hotdoc.utils.loggable import info, debug
 
 
 NS_MAP = {'core': 'http://www.gtk.org/introspection/core/1.0',

--- a/hotdoc/extensions/gi/utils.py
+++ b/hotdoc/extensions/gi/utils.py
@@ -2,7 +2,7 @@ import os
 from collections import namedtuple
 import pathlib
 
-import pkg_resources
+from backports.entry_points_selectable import entry_points
 
 from hotdoc.core.links import Link
 
@@ -200,16 +200,17 @@ def get_language_classes():
     Banana banana
     """
     all_classes = {}
-    deps_map = {}
 
-    for entry_point in pkg_resources.iter_entry_points(
-            group='hotdoc.extensions.gi.languages', name='get_language_classes'):
+    for entry_point in entry_points(
+            group='hotdoc.extensions.gi.languages',
+            name='get_language_classes'):
         try:
+            ep_name = entry_point.name
             activation_function = entry_point.load()
             classes = activation_function()
         # pylint: disable=broad-except
         except Exception as exc:
-            info("Failed to load %s" % entry_point.module_name, exc)
+            info("Failed to load %s" % entry_point, exc)
             debug(traceback.format_exc())
             continue
 

--- a/hotdoc/utils/utils.py
+++ b/hotdoc/utils/utils.py
@@ -211,7 +211,7 @@ def __load_extra_extension_modules(paths: T.List[str]) -> T.List[T.Type['Extensi
             spec.loader.exec_module(ext_mod)
             extra_classes += ext_mod.get_extension_classes()
         except Exception as exc:
-            warn('extension-import', f'Faield to import extension {p}')
+            warn('extension-import', f'Failed to import extension {p}')
     return extra_classes
 
 

--- a/hotdoc/utils/utils.py
+++ b/hotdoc/utils/utils.py
@@ -165,7 +165,7 @@ def __get_extra_extension_classes(paths):
         # pylint: disable=broad-except
         except Exception as exc:
             warn('extension-import', "Failed to load %s %s" %
-                 (entry_point, exc))
+                 (str(entry_point), exc))
             debug(traceback.format_exc())
             continue
 
@@ -216,7 +216,7 @@ def get_extension_classes(sort: bool,
             classes = activation_function()
         # pylint: disable=broad-except
         except Exception as exc:
-            info("Failed to load %s" % entry_point, exc)
+            info("Failed to load %s" % str(entry_point), exc)
             debug(traceback.format_exc())
             continue
 

--- a/hotdoc/utils/utils.py
+++ b/hotdoc/utils/utils.py
@@ -168,7 +168,7 @@ def __load_entry_point(
 
 def __get_extra_extension_classes(paths):
     """
-    Banana banana
+    Identify and load extension packages from external paths.
     """
     extra_classes = []
 
@@ -199,7 +199,7 @@ def __get_extra_extension_classes(paths):
 
 def __load_extra_extension_modules(paths: T.List[str]) -> T.List[T.Type['Extension']]:
     """
-    Banana banana
+    Load individual extension modules from specified file paths.
     """
     extra_classes = []
     for p in [Path(x) for x in paths]:

--- a/hotdoc/utils/utils.py
+++ b/hotdoc/utils/utils.py
@@ -35,6 +35,10 @@ from urllib.request import urlretrieve
 from pathlib import Path
 
 from backports.entry_points_selectable import entry_points
+try:
+    import importlib.metadata as meta
+except ImportError:
+    import importlib_metadata as meta
 
 from toposort import toposort_flatten
 

--- a/setup.py
+++ b/setup.py
@@ -299,6 +299,7 @@ INSTALL_REQUIRES = [
     'appdirs',
     'wheezy.template',
     'toposort>=1.4',
+    'importlib_metadata; python_version<"3.10"',
     'backports.entry_points_selectable',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -299,6 +299,7 @@ INSTALL_REQUIRES = [
     'appdirs',
     'wheezy.template',
     'toposort>=1.4',
+    'backports.entry_points_selectable',
 ]
 
 # dbus-deviation requires sphinx, which requires python 3.5


### PR DESCRIPTION
This PR eliminates use of setuptools' [deprecated](https://setuptools.pypa.io/en/latest/pkg_resources.html#package-discovery-and-resource-access-using-pkg-resources) `pkg_resources` in `hotdoc.utils.utils` and `hotdoc.extensions.gi.utils`, substituting equivalent APIs provided by `importlib.metadata.entry_points()`.

The `entry_points()` function used is actually imported from `backports.entry_points_selectable` (a new dependency, added to `setup.py`), which ensures that calls to `entry_points()` can take filtering arguments even in Python < 3.10, where `importlib.metadata` didn't natively support such usage.

(In practice, for recent Python 3.10+ releases, `backports.entry_points_selectable.entry_points` will be `importlib.metadata.entry_points`.)

The resulting `hotdoc` package passes all unit tests in `hotdoc.tests` on Python 3.12, even in a virtual environment with the `setuptools` package removed:

```console
$ python3 -m unittest
.............................................................................................................
/usr/lib64/python3.12/tempfile.py:936: ResourceWarning:
 Implicitly cleaning up <TemporaryDirectory '/tmp/tmpe0jsh57p'>
  _warnings.warn(warn_message, ResourceWarning)
............
----------------------------------------------------------------------
Ran 121 tests in 3.232s

OK
```

`hotdoc` from the `master` branch, in that same situation, fails several tests outright, and skips over 80% of them:

```console
$ python3 -m unittest
[...]
======================================================================
ERROR: hotdoc.tests.test_hotdoc (unittest.loader._FailedTest.hotdoc.tests.test_hotdoc)
----------------------------------------------------------------------
ImportError: Failed to import test module: hotdoc.tests.test_hotdoc
Traceback (most recent call last):
  File "/usr/lib64/python3.12/unittest/loader.py", line 394, in _find_test_path
    module = self._get_module_from_name(name)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/unittest/loader.py", line 337, in _get_module_from_name
    __import__(name)
  File ".../hotdoc/tests/test_hotdoc.py", line 30, in <module>
    from hotdoc.utils.utils import touch
  File ".../hotdoc/utils/utils.py", line 37, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'


----------------------------------------------------------------------
Ran 19 tests in 0.002s

FAILED (errors=11)
```
