### PR TITLE
gi: Don't assume position of callback child within fields

### DIFF
--- a/hotdoc/extensions/gi/gi_extension.py
+++ b/hotdoc/extensions/gi/gi_extension.py
@@ -350,7 +350,11 @@ class GIExtension(Extension):
             if field.attrib.get('private', False):
                 continue
 
-            if children[0].tag == core_ns('callback'):
+            is_callback = False
+            for c in children:
+                if c.tag == core_ns('callback'):
+                    is_callback = True
+            if is_callback:
                 continue
 
             type_desc = type_description_from_node(field)


### PR DESCRIPTION
Since gobject-introspection 1.80 other fields are added (like documentation) and therefore the callback child might actualy be the 2nd child.

