### PR TITLE
avoid third-party backports dependency on sufficiently new python

### DIFF
--- a/hotdoc/extensions/gi/utils.py
+++ b/hotdoc/extensions/gi/utils.py
@@ -1,9 +1,13 @@
 import os
 from collections import namedtuple
 import pathlib
+import sys
 import traceback
 
-from backports.entry_points_selectable import entry_points
+if sys.version_info >= (3, 10):
+    from importlib.metadata import entry_points
+else:
+    from backports.entry_points_selectable import entry_points
 
 from hotdoc.core.links import Link
 from hotdoc.utils.loggable import info, debug

--- a/hotdoc/utils/utils.py
+++ b/hotdoc/utils/utils.py
@@ -35,7 +35,11 @@ import importlib.util
 from urllib.request import urlretrieve
 from pathlib import Path
 
-from backports.entry_points_selectable import entry_points
+if sys.version_info >= (3, 10):
+    from importlib.metadata import entry_points
+else:
+    from backports.entry_points_selectable import entry_points
+
 try:
     import importlib.metadata as meta
 except ImportError:

--- a/setup.py
+++ b/setup.py
@@ -300,7 +300,7 @@ INSTALL_REQUIRES = [
     'wheezy.template',
     'toposort>=1.4',
     'importlib_metadata; python_version<"3.10"',
-    'backports.entry_points_selectable',
+    'backports.entry_points_selectable; python_version<"3.10"',
 ]
 
 # dbus-deviation requires sphinx, which requires python 3.5


### PR DESCRIPTION
`backports.entry_points_selectable` backports functionality from python 3.10 to older versions of python.