### PR TITLE
CI: Remove eol Python versions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.11]
+        python-version: [3.10, 3.11]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
See https://devguide.python.org/versions for a list of the current versions.