### PR TITLE
CI: Python version are strings

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10, 3.11]
+        python-version: ['3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Otherwise Python 3.10 is considered as 3.1 by GitHub Actions…