### PR TITLE
gst: Remove dependency on devhelp

### DIFF
--- a/hotdoc/extensions/gst/gst_extension.py
+++ b/hotdoc/extensions/gst/gst_extension.py
@@ -43,7 +43,6 @@ from hotdoc.core.comment import Comment
 from hotdoc.extensions.gi.gi_extension import WritableFlag, ReadableFlag, \
     ConstructFlag, ConstructOnlyFlag
 from hotdoc.extensions.gi.symbols import GIClassSymbol, GIInterfaceSymbol
-from hotdoc.extensions.devhelp.devhelp_extension import TYPE_MAP
 
 
 DESCRIPTION =\
@@ -1139,6 +1138,4 @@ class GstExtension(Extension):
         link_resolver.get_link_signal.disconnect(
             search_online_links)
 
-
-TYPE_MAP.update({GstNamedConstantsSymbols: 'enum'})
 _inject_fundamentals()


### PR DESCRIPTION
GstNamedConstantsSymbols is already a EnumSymbol subclass

Follow-up from https://github.com/hotdoc/hotdoc/pull/304