### PR TITLE
CI: Add wheel build workflow for Linux and macOS

### DIFF
--- a/.github/workflows/wheels-before-all-linux.sh
+++ b/.github/workflows/wheels-before-all-linux.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Install native dependencies needed to build hotdoc wheels inside the
+# manylinux_2_28 (AlmaLinux 8) container used by cibuildwheel.
+set -euxo pipefail
+
+dnf install -y 'dnf-command(config-manager)'
+dnf config-manager --set-enabled powertools
+dnf install -y glib2-devel libxml2-devel json-glib-devel cmake flex
+dnf module install -y nodejs:18

--- a/.github/workflows/wheels-before-all-macos.sh
+++ b/.github/workflows/wheels-before-all-macos.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Install native dependencies needed to build hotdoc wheels on macOS.
+# Homebrew installs libxml2's pkg-config files in a keg-only prefix, so link
+# them into the main Homebrew prefix where pkg-config will find them.
+set -euxo pipefail
+
+brew install glib libxml2 json-glib cmake
+ln -sf "$(brew --prefix libxml2)"/lib/pkgconfig/*.pc "$(brew --prefix)/lib/pkgconfig/"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,29 @@
+name: Build wheels
+
+on:
+  push:
+    branches:
+      - wheels
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build_wheels:
+    name: Build wheels (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: pypa/cibuildwheel@v2.22
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,16 @@ get_extension_classes = "hotdoc.extensions:get_extension_classes"
 
 [project.entry-points."hotdoc.extensions.gi.languages"]
 get_language_classes = "hotdoc.extensions.gi.languages:get_language_classes"
+
+[tool.cibuildwheel]
+build = "cp310-* cp311-* cp312-* cp313-*"
+skip = "*-manylinux_i686 *-musllinux*"
+
+[tool.cibuildwheel.linux]
+manylinux-x86_64-image = "manylinux_2_28"
+before-all = "{project}/.github/workflows/wheels-before-all-linux.sh"
+
+[tool.cibuildwheel.macos]
+archs = ["native"]
+before-all = "{project}/.github/workflows/wheels-before-all-macos.sh"
+environment = { MACOSX_DEPLOYMENT_TARGET = "15.0" }


### PR DESCRIPTION
Uses cibuildwheel with per-platform native dependency installation (glib, libxml2, json-glib, cmake, flex) and automatic shared library bundling via auditwheel/delocate/delvewheel.


We should setup pypi and have release automatically be built.